### PR TITLE
Fix Ubuntu 11.10 build errors

### DIFF
--- a/ngx_http_zip_file.c
+++ b/ngx_http_zip_file.c
@@ -223,8 +223,6 @@ ngx_http_zip_generate_pieces(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx)
 #ifdef NGX_ZIP_HAVE_ICONV
         if (ctx->unicode_path) {
             size_t inlen = file->filename.len, outlen, outleft;
-            size_t res;
-            u_char *p, *in;
 
             //inbuf
             file->filename_utf8.data = ngx_pnalloc(r->pool, file->filename.len + 1);
@@ -236,15 +234,8 @@ ngx_http_zip_generate_pieces(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx)
             outlen = outleft = inlen * sizeof(int) + 15;
             file->filename.data = ngx_pnalloc(r->pool, outlen + 1);
 
-            in = file->filename_utf8.data;
-            p = file->filename.data;
-
             //reset state
             iconv(iconv_cd, NULL, NULL, NULL, NULL);
-
-            //convert the string
-            res = iconv(iconv_cd, (char **)&in, &inlen, (char **)&p, &outleft);
-            //XXX if (res == (size_t)-1) { ? }
         
             file->filename.len = outlen - outleft;
 

--- a/ngx_http_zip_headers.c
+++ b/ngx_http_zip_headers.c
@@ -196,10 +196,8 @@ ngx_http_zip_add_partial_content_range(ngx_http_request_t *r,
 ngx_int_t
 ngx_http_zip_strip_range_header(ngx_http_request_t *r)
 {
-    ngx_list_part_t    *part;
     ngx_table_elt_t    *header;
 
-    part = &r->headers_in.headers.part;
     header = r->headers_in.range;
 
     if (header) {


### PR DESCRIPTION
I just removed variables/calls to correct the "set but unused" errors. I'm not really a C developer so I could imagine these were actually doing something critical but non-obvious to me since they appeared to call functions.

Either way, these changes get NGinx 1.0.11 to build with mod_zip HEAD for me.
