### PR TITLE
Fix nginx linking to iconv

### DIFF
--- a/config
+++ b/config
@@ -21,3 +21,8 @@ case "$NGX_PLATFORM" in
 esac
 ngx_feature_test="iconv_open(\"IBM-850\", \"ISO8859-1\");"
 . auto/feature
+
+if [ $ngx_found = yes ]; then
+    CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
+    ngx_found=no
+fi


### PR DESCRIPTION
Building nginx 1.0.14 + mod_zip on OS X 10.7 was failing because the generated `Makefile` did not include `-liconv`. This commit fixes the config script to allow linking.
