### PR TITLE
support for non-upstream,like ngx_lua

### DIFF
--- a/ngx_http_zip_module.c
+++ b/ngx_http_zip_module.c
@@ -192,9 +192,19 @@ ngx_http_zip_main_request_header_filter(ngx_http_request_t *r)
         return NGX_ERROR;
   
     /* Look for X-Archive-Files */
-    if (ngx_http_upstream_header_variable(r, vv, (uintptr_t)(&ngx_http_zip_header_variable_name)) != NGX_OK 
-            || vv->not_found || ngx_strncmp(vv->data, "zip", sizeof("zip") - 1) != 0)
+    if ( !r->upstream && ( ngx_http_variable_unknown_header(vv, &ngx_http_zip_header_variable_name,
+                                         &r->headers_out.headers.part,
+                                         sizeof("upstream_http_") - 1) != NGX_OK)
+            || vv->not_found || ngx_strncmp(vv->data, "zip", sizeof("zip") - 1) != 0){
+
         return ngx_http_next_header_filter(r);
+
+    }else if (r->upstream && ngx_http_upstream_header_variable(r, vv, 
+                            (uintptr_t)(&ngx_http_zip_header_variable_name)) != NGX_OK 
+            || vv->not_found || ngx_strncmp(vv->data, "zip", sizeof("zip") - 1) != 0){
+
+        return ngx_http_next_header_filter(r);
+    }
     
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "mod_zip: X-Archive-Files found");
 


### PR DESCRIPTION
use ngx_lua make response body, r->upstream is always NULL, mod_zip does not work.
add support non-upstream!
