### PR TITLE
Enable Travis-CI for continuously running the tests 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: c
+compiler:
+  - clang
+  - gcc
+
+before_install:
+  - sudo apt-get install libwww-perl libarchive-zip-perl
+
+script:
+  - wget http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
+  - tar xvfz nginx-${NGINX_VERSION}.tar.gz
+  - cd nginx-${NGINX_VERSION}
+  - ./configure --prefix=${TRAVIS_BUILD_DIR}/t/nginx --add-module=${TRAVIS_BUILD_DIR}
+  - make
+  - make install
+  - cd ${TRAVIS_BUILD_DIR}/t
+  - ./restart.sh
+  - ./ziptest.pl
+
+env:
+  - NGINX_VERSION="1.6.2"
+  - NGINX_VERSION="1.7.10"
+

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,6 @@
 mod_zip
 =======
+[![Build Status](https://travis-ci.org/evanmiller/mod_zip.svg?branch=master)](https://travis-ci.org/evanmiller/mod_zip)
 
 mod_zip assembles ZIP archives dynamically. It can stream component files from
 upstream servers with nginx's native proxying code, so that the process never


### PR DESCRIPTION
This is more of an administrative change rather than a code change, but I believe it could be beneficial.

If we enable Travis-CI for this repository, it will automatically run the entire test suite against [multiple nginx versions](https://github.com/anthonyryan1/mod_zip/blob/66f575d33dffd9bca53a7fc25f569b81fd7bfb9f/.travis.yml#L20-L22) and [compilers](https://github.com/anthonyryan1/mod_zip/blob/66f575d33dffd9bca53a7fc25f569b81fd7bfb9f/.travis.yml#L2-L4) for every commit and pull request. This continuous testing will help find regressions sooner so they can be addressed promptly.

In addition to creating the .travis.yml file the following steps are necessary:
* Visit https://travis-ci.org/
* Sign in with Github
* Grant Travis-CI limited permissions to your github account
* Visit https://travis-ci.org/profile/evanmiller
* Turn on testing for mod_zip

-----------

It is notable that at the moment the tests are red. There is a failure with the **Has data descriptor when missing CRC** and **Generated file1.txt CRC is correct** tests. If you would rather get the tests passing before advertising their state in the README, I will set aside some time to try and get the remaining tests passing before this gets enabled.