### PR TITLE
Use carton to install modules from cpan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,33 @@ compiler:
   - gcc
 
 before_install:
-  - sudo apt-get install libwww-perl libarchive-zip-perl
+  # Ubuntu 12.04 doesn't have carton natively, so we install the copy from trusty
+  # This can be removed when Travis CI updates to 14.04
+  # https://github.com/travis-ci/travis-ci/issues/2046
+  - lsb_release -r
+  - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty main universe multiverse'
+  - sudo apt-get update
 
-script:
+  # Ubuntu's versions of these packages are out of date so we need
+  # to install them using carton instead.
+  - sudo apt-get --no-install-recommends install carton
+
+  # Fetch nginx source
   - wget http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
   - tar xvfz nginx-${NGINX_VERSION}.tar.gz
   - cd nginx-${NGINX_VERSION}
+
+script:
+  # Build nginx
   - ./configure --prefix=${TRAVIS_BUILD_DIR}/t/nginx --add-module=${TRAVIS_BUILD_DIR}
   - make
   - make install
+
+  # Run tests
   - cd ${TRAVIS_BUILD_DIR}/t
   - ./restart.sh
-  - ./ziptest.pl
+  - carton install
+  - carton exec ./ziptest.pl
 
 env:
   - NGINX_VERSION="1.6.2"

--- a/ngx_http_zip_module.h
+++ b/ngx_http_zip_module.h
@@ -11,7 +11,7 @@
 extern uint32_t   ngx_crc32_table256[];
 
 typedef struct {
-    ngx_uint_t  crc32;
+    uint32_t    crc32;
     ngx_str_t   uri;
     ngx_str_t   args;
     size_t      index; //! zip64 allows for 64bit number of files

--- a/ngx_http_zip_parsers.c
+++ b/ngx_http_zip_parsers.c
@@ -296,33 +296,26 @@ _match:
             if ((*p) == '-') {
                 ctx->missing_crc32 = 1;
                 parsing_file->missing_crc32 = 1;
-                parsing_file->crc32 = 0xffffffff;
+                ngx_crc32_init(parsing_file->crc32);
             } else {
                 parsing_file->crc32 *= 16;
-                if ((*p) >= 'a' && (*p) <= 'f') {
-                    parsing_file->crc32 += (*p) - 'a' + 10;
-                }
-                else if ((*p) >= 'A' && (*p) <= 'F') {
-                    parsing_file->crc32 += (*p) - 'A' + 10;
-                } else { /* 0-9 */
-                    parsing_file->crc32 += (*p) - '0';
-                }
+                parsing_file->crc32 += ngx_hextoi(p, 1);
             }
         }
 	break;
 	case 7:
-#line 148 "ngx_http_zip_parsers.rl"
+#line 141 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->filename.data = p;
         }
 	break;
 	case 8:
-#line 151 "ngx_http_zip_parsers.rl"
+#line 144 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->filename.len = p - parsing_file->filename.data;
         }
 	break;
-#line 326 "ngx_http_zip_parsers.c"
+#line 319 "ngx_http_zip_parsers.c"
 		}
 	}
 
@@ -339,12 +332,12 @@ _again:
 	while ( __nacts-- > 0 ) {
 		switch ( *__acts++ ) {
 	case 8:
-#line 151 "ngx_http_zip_parsers.rl"
+#line 144 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->filename.len = p - parsing_file->filename.data;
         }
 	break;
-#line 348 "ngx_http_zip_parsers.c"
+#line 341 "ngx_http_zip_parsers.c"
 		}
 	}
 	}
@@ -352,7 +345,7 @@ _again:
 	_out: {}
 	}
 
-#line 169 "ngx_http_zip_parsers.rl"
+#line 162 "ngx_http_zip_parsers.rl"
 
 
     /* suppress warning */
@@ -368,7 +361,7 @@ _again:
 }
 
 
-#line 372 "ngx_http_zip_parsers.c"
+#line 369 "ngx_http_zip_parsers.c"
 static const char _range_actions[] = {
 	0, 1, 0, 1, 1, 1, 2, 2, 
 	0, 1, 2, 3, 1
@@ -419,7 +412,7 @@ static const int range_start = 1;
 static const int range_en_main = 1;
 
 
-#line 186 "ngx_http_zip_parsers.rl"
+#line 179 "ngx_http_zip_parsers.rl"
 
 
 ngx_int_t
@@ -432,12 +425,12 @@ ngx_http_zip_parse_range(ngx_http_request_t *r, ngx_str_t *range_str, ngx_http_z
     u_char *pe = range_str->data + range_str->len;
 
     
-#line 436 "ngx_http_zip_parsers.c"
+#line 433 "ngx_http_zip_parsers.c"
 	{
 	cs = range_start;
 	}
 
-#line 441 "ngx_http_zip_parsers.c"
+#line 438 "ngx_http_zip_parsers.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -511,7 +504,7 @@ _match:
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 198 "ngx_http_zip_parsers.rl"
+#line 191 "ngx_http_zip_parsers.rl"
 	{
             if (range) {
                 if (ngx_http_zip_clean_range(range, prefix, suffix, ctx) == NGX_ERROR) {
@@ -527,18 +520,18 @@ _match:
         }
 	break;
 	case 1:
-#line 212 "ngx_http_zip_parsers.rl"
+#line 205 "ngx_http_zip_parsers.rl"
 	{ range->start = range->start * 10 + ((*p) - '0'); }
 	break;
 	case 2:
-#line 214 "ngx_http_zip_parsers.rl"
+#line 207 "ngx_http_zip_parsers.rl"
 	{ range->end = range->end * 10 + ((*p) - '0'); prefix = 0; }
 	break;
 	case 3:
-#line 216 "ngx_http_zip_parsers.rl"
+#line 209 "ngx_http_zip_parsers.rl"
 	{ suffix = 1; }
 	break;
-#line 542 "ngx_http_zip_parsers.c"
+#line 539 "ngx_http_zip_parsers.c"
 		}
 	}
 
@@ -551,7 +544,7 @@ _again:
 	_out: {}
 	}
 
-#line 229 "ngx_http_zip_parsers.rl"
+#line 222 "ngx_http_zip_parsers.rl"
 
 
     /* suppress warning */

--- a/ngx_http_zip_parsers.rl
+++ b/ngx_http_zip_parsers.rl
@@ -132,17 +132,10 @@ ngx_http_zip_parse_request(ngx_http_zip_ctx_t *ctx)
             if (fc == '-') {
                 ctx->missing_crc32 = 1;
                 parsing_file->missing_crc32 = 1;
-                parsing_file->crc32 = 0xffffffff;
+                ngx_crc32_init(parsing_file->crc32);
             } else {
                 parsing_file->crc32 *= 16;
-                if (fc >= 'a' && fc <= 'f') {
-                    parsing_file->crc32 += fc - 'a' + 10;
-                }
-                else if (fc >= 'A' && fc <= 'F') {
-                    parsing_file->crc32 += fc - 'A' + 10;
-                } else { /* 0-9 */
-                    parsing_file->crc32 += fc - '0';
-                }
+                parsing_file->crc32 += ngx_hextoi(fpc, 1);
             }
         }
         action start_filename {

--- a/t/cpanfile
+++ b/t/cpanfile
@@ -1,0 +1,2 @@
+requires 'Archive::Zip', '>=1.45';
+requires 'LWP::UserAgent';

--- a/t/nginx/html/zip-uppercase-crc.txt
+++ b/t/nginx/html/zip-uppercase-crc.txt
@@ -1,0 +1,2 @@
+1A6349C5 24 /file1.txt file1.txt
+5D70C4d3 25 /file2.txt file2.txt

--- a/t/ziptest.pl
+++ b/t/ziptest.pl
@@ -2,7 +2,7 @@
 
 # TODO tests for Zip64
 
-use Test::More tests => 88;
+use Test::More tests => 93;
 use LWP::UserAgent;
 use Archive::Zip;
 
@@ -114,6 +114,12 @@ is($zip->memberNamed("file1.txt")->hasDataDescriptor(), 8, "Has data descriptor 
 is($zip->memberNamed("file1.txt")->crc32String(), "1a6349c5", "Generated file1.txt CRC is correct");
 is($zip->memberNamed("file2.txt")->crc32String(), "5d70c4d3", "Generated file2.txt CRC is correct");
 
+$response = $ua->get("$http_root/zip-uppercase-crc.txt");
+is($response->code, 200, "Returns OK with uppercase CRC");
+$zip = test_zip_archive($response->content, "with uppercase CRC");
+is($zip->memberNamed("file1.txt")->crc32String(), "1a6349c5", "file1.txt CRC is correct");
+is($zip->memberNamed("file2.txt")->crc32String(), "5d70c4d3", "file2.txt CRC is correct");
+
 $response = $ua->get("$http_root/zip-404.txt");
 is($response->code, 500, "Server error with bad file");
 
@@ -128,8 +134,8 @@ is($response->code, 200, "Returns OK with local files");
 
 $zip = test_zip_archive($response->content, "with local files");
 is($zip->numberOfMembers(), 2, "Correct number in local-file ZIP");
-is($zip->memberNamed("file1.txt")->crc32String(), "1a6349c5", "Generated file1.txt CRC is correct (local)");
-is($zip->memberNamed("file2.txt")->crc32String(), "5d70c4d3", "Generated file2.txt CRC is correct (local)");
+is($zip->memberNamed("file1.txt")->crc32String(), "1a6349c5", "file1.txt CRC is correct (local)");
+is($zip->memberNamed("file2.txt")->crc32String(), "5d70c4d3", "file2.txt CRC is correct (local)");
 
 $response = $ua->get("$http_root/zip-spaces.txt");
 is($response->code, 200, "Returns OK with spaces in URLs");


### PR DESCRIPTION
Currently the perl packages shipped with Ubuntu are significantly outdated and causing
false-failures in the test suite.

* Start using the built-in ngx_crc32_* where compatible.
* Add test case for uppercase crc32s to avoid possible regressions when
  converting to ngx built-in methods.

As always I am open to comments and criticism.