### PR TITLE
Explicitly depend upon the http_postpone_filter_module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,5 @@ script:
 
 env:
   - NGINX_VERSION="1.6.2"
-  - NGINX_VERSION="1.7.10"
+  - NGINX_VERSION="1.7.12"
 

--- a/config
+++ b/config
@@ -5,6 +5,10 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_parsers.c"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_file.c"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_headers.c"
 
+
+# This module depends upon the postpone filter being activated
+HTTP_MODULES="$HTTP_MODULES ngx_http_postpone_filter"
+
 ngx_feature="iconv_open()"
 ngx_feature_name="NGX_ZIP_HAVE_ICONV"
 ngx_feature_run=no


### PR DESCRIPTION
Previously mod_zip would mangle the output chain if another module did not happen to require the postpone_filter module. By making this dependency explicit we can avoid a bug when nginx is compiled with certain configuration options.

Fixes #17 

I also bumped the 1.7 version we're testing against. Simply because there's a newer 1.7.x release out.