### PR TITLE
Explicitly depend upon the http_postpone_filter_module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ script:
   - carton exec ./ziptest.pl
 
 env:
-  - NGINX_VERSION="1.6.2"
-  - NGINX_VERSION="1.7.10"
+  - NGINX_VERSION="1.6.3"
+  - NGINX_VERSION="1.7.12"
+  - NGINX_VERSION="1.8.0"
+  - NGINX_VERSION="1.9.0"
 

--- a/config
+++ b/config
@@ -5,6 +5,13 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_parsers.c"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_file.c"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_headers.c"
 
+
+# This module depends upon the postpone filter being activated
+if [ $HTTP_POSTPONE != YES ]; then
+    HTTP_FILTER_MODULES="$HTTP_FILTER_MODULES $HTTP_POSTPONE_FILTER_MODULE"
+    HTTP_SRCS="$HTTP_SRCS $HTTP_POSTPONE_FILTER_SRCS"
+fi
+
 ngx_feature="iconv_open()"
 ngx_feature_name="NGX_ZIP_HAVE_ICONV"
 ngx_feature_run=no


### PR DESCRIPTION
Previously mod_zip would mangle the output chain if another module
did not happen to require the postpone_filter module. By making this
dependency explicit we can avoid a bug when nginx is compiled with
certain configuration options.

Fixes #17