### PR TITLE
ngx_http_variable_unknown_header was causing segfaults

### DIFF
--- a/ngx_http_zip_headers.c
+++ b/ngx_http_zip_headers.c
@@ -31,8 +31,7 @@ ngx_http_zip_add_cache_control(ngx_http_request_t *r)
         }
 
         cc->hash = 1;
-        cc->key.len = sizeof("Cache-Control") - 1;
-        cc->key.data = (u_char *) "Cache-Control";
+        ngx_str_set(&cc->key, "Cache-Control");
 
         *ccp = cc;
 
@@ -44,8 +43,7 @@ ngx_http_zip_add_cache_control(ngx_http_request_t *r)
         cc = ccp[0];
     }
 
-    cc->value.len = sizeof("max-age=0") - 1;
-    cc->value.data = (u_char *) "max-age=0";
+    ngx_str_set(&cc->value, "max-age=0");
 
     return NGX_OK;
 }
@@ -63,8 +61,7 @@ ngx_http_zip_add_content_range_header(ngx_http_request_t *r)
     r->headers_out.content_range = content_range;
 
     content_range->hash = 1;
-    content_range->key.len = sizeof("Content-Range") - 1;
-    content_range->key.data = (u_char *) "Content-Range";
+    ngx_str_set(&content_range->key, "Content-Range");
 
     if (r->headers_out.content_length) {
         r->headers_out.content_length->hash = 0;
@@ -201,8 +198,7 @@ ngx_http_zip_strip_range_header(ngx_http_request_t *r)
     header = r->headers_in.range;
 
     if (header) {
-        header->key.data    = (u_char *)"X-Range";
-        header->key.len     = sizeof("X-Range") - 1;
+        ngx_str_set(&header->key, "X-Range");
         header->lowcase_key = (u_char *)"x-range";
     }
 

--- a/ngx_http_zip_module.c
+++ b/ngx_http_zip_module.c
@@ -196,10 +196,12 @@ ngx_http_zip_main_request_header_filter(ngx_http_request_t *r)
     if (r->upstream) {
         variable_header_status = ngx_http_upstream_header_variable(r, vv, 
                 (uintptr_t)(&ngx_http_zip_header_variable_name));
-    } else {
+    } else if (r->headers_out.status == NGX_HTTP_OK) {
         variable_header_status = ngx_http_variable_unknown_header(vv, 
                 &ngx_http_zip_header_variable_name,
                 &r->headers_out.headers.part, sizeof("upstream_http_") - 1); 
+    } else {
+        vv->not_found = 1;
     }
 
     if (variable_header_status != NGX_OK || vv->not_found || 


### PR DESCRIPTION
ngx_http_variable_unknown_header was causing segfaults during NPN negotiation and other requests that did not include non-null content in headers_out.headers.part.

We solved this my making sure there's an OK status going out together with the non-upstream content.

Fixes #30