### PR TITLE
Added flush to chain with zip headers. Fixes #44.

### DIFF
--- a/ngx_http_zip_file.c
+++ b/ngx_http_zip_file.c
@@ -429,7 +429,7 @@ ngx_http_zip_file_header_chain_link(ngx_http_request_t *r, ngx_http_zip_ctx_t *c
 
     b->memory = 1;
     b->last = b->pos + len;
-    b->flush = 1;
+    b->flush = piece > ctx->pieces;
 
     /* A note about the ZIP format: in order to appease all ZIP software I
      * could find, the local file header contains the file sizes but not the

--- a/ngx_http_zip_file.c
+++ b/ngx_http_zip_file.c
@@ -429,6 +429,7 @@ ngx_http_zip_file_header_chain_link(ngx_http_request_t *r, ngx_http_zip_ctx_t *c
 
     b->memory = 1;
     b->last = b->pos + len;
+    b->flush = 1;
 
     /* A note about the ZIP format: in order to appease all ZIP software I
      * could find, the local file header contains the file sizes but not the


### PR DESCRIPTION
It seems that adding flush to chain with zip headers prevents ssl module from stalling.