### PR TITLE
Flush file header under SSL. Fixes #44

### DIFF
--- a/ngx_http_zip_file.c
+++ b/ngx_http_zip_file.c
@@ -429,6 +429,9 @@ ngx_http_zip_file_header_chain_link(ngx_http_request_t *r, ngx_http_zip_ctx_t *c
 
     b->memory = 1;
     b->last = b->pos + len;
+#if (NGX_HTTP_SSL)
+    b->flush = r->connection->ssl;
+#endif
 
     /* A note about the ZIP format: in order to appease all ZIP software I
      * could find, the local file header contains the file sizes but not the


### PR DESCRIPTION
Flushing fixes the reported issues with SSL, but it comes with the cost of sending a 200 OK response when a subrequest has failed. There is probably a better solution, but flushing only under SSL fixes the bugs people are experiencing and preserves the error behavior under non-SSL.