### PR TITLE
Require SSI & friends to pull in postpone

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,8 +15,9 @@ To install, compile nginx with the following option:
 
     --add-module=/path/to/this/directory
 
-nginx 0.7.25 or later is required. If libiconv is present, support for the
-"X-Archive-Charset" header is enabled; see below.
+* nginx 0.7.25 or later is required
+* (optional) to enable the "X-Archive-Charset" header, libiconv is required
+* http_postpone must be enabled by including at least one of the http_addition, http_slice or http_ssi modules
 
 
 Usage

--- a/config
+++ b/config
@@ -5,13 +5,6 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_parsers.c"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_file.c"
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_headers.c"
 
-
-# This module depends upon the postpone filter being activated
-if [ $HTTP_POSTPONE != YES ]; then
-    HTTP_FILTER_MODULES="$HTTP_FILTER_MODULES $HTTP_POSTPONE_FILTER_MODULE"
-    HTTP_SRCS="$HTTP_SRCS $HTTP_POSTPONE_FILTER_SRCS"
-fi
-
 ngx_feature="iconv_open()"
 ngx_feature_name="NGX_ZIP_HAVE_ICONV"
 ngx_feature_run=no


### PR DESCRIPTION
The nginx build system was modified in 1.9.11 in a way that breaks
the hack we had previously been using to pull in the postpone module.

The upstream has expressed that they don't feel this is a flaw in
their build system since ssi is enabled by default (pulling in
postpone).

Rather than pile more hacks on the pile, we're going to throw in
the towel and just document the limitation under the installation
section of the README.

Closes #52
Closes #51
Reference: http://mailman.nginx.org/pipermail/nginx-devel/2016-April/008172.html