### PR TITLE
Allows mod_zip to be compiled as a dynamic module.

### DIFF
--- a/config
+++ b/config
@@ -1,16 +1,18 @@
 ngx_addon_name=ngx_http_zip_module
 
-if test -n "$ngx_module_link"; then
+if [ $ngx_module_link = DYNAMIC ] ; then
     ngx_module_name=ngx_http_zip_module
     ngx_module_srcs="$ngx_addon_dir/ngx_http_zip_module.c $ngx_addon_dir/ngx_http_zip_parsers.c $ngx_addon_dir/ngx_http_zip_file.c $ngx_addon_dir/ngx_http_zip_headers.c"
 
     . auto/module
-else
+elif [ $ngx_module_link = ADDON ] ; then
     HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_zip_module"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_module.c"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_parsers.c"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_file.c"
     NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_headers.c"
+
+    . auto/module    
 fi
 
 ngx_feature="iconv_open()"

--- a/config
+++ b/config
@@ -1,9 +1,17 @@
 ngx_addon_name=ngx_http_zip_module
-HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_zip_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_module.c"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_parsers.c"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_file.c"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_headers.c"
+
+if test -n "$ngx_module_link"; then
+    ngx_module_name=ngx_http_zip_module
+    ngx_module_srcs="$ngx_addon_dir/ngx_http_zip_module.c $ngx_addon_dir/ngx_http_zip_parsers.c $ngx_addon_dir/ngx_http_zip_file.c $ngx_addon_dir/ngx_http_zip_headers.c"
+
+    . auto/module
+else
+    HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_zip_module"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_module.c"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_parsers.c"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_file.c"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_zip_headers.c"
+fi
 
 ngx_feature="iconv_open()"
 ngx_feature_name="NGX_ZIP_HAVE_ICONV"


### PR DESCRIPTION
I believe I've made the appropriate changes to allow mod_zip to be compiled as a dynamic module. It works for me, at least (under 1.10.3 on Debian Jessie Backports).

This is the first time I've really touched any nginx modules, so I'm not entirely au fait with it's configuration mechanisms. If this has broken anything, or something needs to be changed, please do tell me and I'll do my best to fix whatever it is that I've broken and update the PR.

For reference, in case it helps me or anyone else, in the future -

I grabbed the source using `apt-get source nginx`, then running `./configure` with the same flags as output from `nginx -v`, with `--add-dynamic-module=../path/to/mod_zip` appended to the end. To test I copied `objs/ngx_http_zip_module.so` into `/usr/lib/nginx/modules` added `/etc/nginx/modules-enabled/50-mod_zip.conf` with the content to load the module, restarted nginx and then ensured it was functioning by calling my configured endpoint.