### PR TITLE
Added ability to declare empty directory

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,12 +44,17 @@ and is what will be extracted from the ZIP file. Example:
 
     1034ab38 428    /foo.txt   My Document1.txt
     83e8110b 100339 /bar.txt   My Other Document1.txt
+    0        0      @directory My empty directory
 
 Files are retrieved and encoded in order. If a file cannot be found or the file
 request returns any sort of error, the download is aborted.
 
 The CRC-32 is optional. Put "-" if you don't know the CRC-32; note that in this
 case mod_zip will disable support for the `Range` header.
+
+A special URL marker `@directory` can be used to declare a directory entry
+within an archive. This is very convenient when you have to package a tree of
+files, including some empty directories. As they have to be declared explicitly.
 
 
 Re-encoding filenames

--- a/ngx_http_zip_file.c
+++ b/ngx_http_zip_file.c
@@ -390,7 +390,7 @@ ngx_http_zip_generate_pieces(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx)
         header_piece->range.end = offset;
 
         file_piece = &ctx->pieces[piece_i++];
-        file_piece->type = zip_file_piece;
+        file_piece->type = file->is_directory ? zip_dir_piece : zip_file_piece;
         file_piece->file = file;
         file_piece->range.start = offset;
         file_piece->range.end = offset += file->size; //!note: (sizeless chunks): we need file size here / or mark it and modify ranges after
@@ -683,6 +683,11 @@ ngx_http_zip_write_central_directory_entry(u_char *p, ngx_http_zip_file_t *file,
     central_directory_file_header.version_made_by = htole16(central_directory_file_header.version_made_by);
     central_directory_file_header.version_needed = htole16(central_directory_file_header.version_needed);
     central_directory_file_header.flags = htole16(central_directory_file_header.flags);
+
+    if (file->is_directory) {
+        central_directory_file_header.attr_external = zip_directory_attr_external;
+    }
+
     central_directory_file_header.attr_external = htole32(central_directory_file_header.attr_external);
     central_directory_file_header.mtime = htole32(file->dos_time);
     central_directory_file_header.crc32 = htole32(file->crc32);

--- a/ngx_http_zip_file_format.h
+++ b/ngx_http_zip_file_format.h
@@ -9,6 +9,9 @@
 #define zip_version_zip64 45
 #define zip_utf8_flag 0x0800
 #define zip_missing_crc32_flag 0x08
+#define zip_directory_attr_external 0x41ED0010
+//                      Unix dir bit -^     ^- DOS dir bit
+//        Unix permission bits (0755) -^^^
 
 typedef struct {
     uint16_t   tag; //0x5455

--- a/ngx_http_zip_module.c
+++ b/ngx_http_zip_module.c
@@ -42,6 +42,8 @@ static ngx_int_t ngx_http_zip_send_header_piece(ngx_http_request_t *r,
         ngx_http_zip_ctx_t *ctx, ngx_http_zip_piece_t *piece, ngx_http_zip_range_t *req_range);
 static ngx_int_t ngx_http_zip_send_file_piece(ngx_http_request_t *r,
         ngx_http_zip_ctx_t *ctx, ngx_http_zip_piece_t *piece, ngx_http_zip_range_t *req_range);
+static ngx_int_t ngx_http_zip_send_directory_piece(ngx_http_request_t *r,
+        ngx_http_zip_ctx_t *ctx, ngx_http_zip_piece_t *piece, ngx_http_zip_range_t *req_range);
 static ngx_int_t ngx_http_zip_send_trailer_piece(ngx_http_request_t *r,
         ngx_http_zip_ctx_t *ctx, ngx_http_zip_piece_t *piece, ngx_http_zip_range_t *req_range);
 static ngx_int_t ngx_http_zip_send_central_directory_piece(ngx_http_request_t *r,
@@ -576,6 +578,13 @@ ngx_http_zip_send_file_piece(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx,
     return NGX_AGAIN;   // must be NGX_AGAIN
 }
 
+static ngx_int_t ngx_http_zip_send_directory_piece(ngx_http_request_t *r,
+        ngx_http_zip_ctx_t *ctx, ngx_http_zip_piece_t *piece, ngx_http_zip_range_t *req_range)
+{
+    // Directory has no data.
+    return NGX_OK;
+}
+
 static ngx_int_t
 ngx_http_zip_send_trailer_piece(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx,
         ngx_http_zip_piece_t *piece, ngx_http_zip_range_t *req_range)
@@ -621,6 +630,8 @@ ngx_http_zip_send_piece(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx,
         rc = ngx_http_zip_send_header_piece(r, ctx, piece, req_range);
     } else if (piece->type == zip_file_piece) {
         rc = ngx_http_zip_send_file_piece(r, ctx, piece, req_range);
+    } else if (piece->type == zip_dir_piece) {
+        rc = ngx_http_zip_send_directory_piece(r, ctx, piece, req_range);
     } else if (piece->type == zip_trailer_piece) {
         rc = ngx_http_zip_send_trailer_piece(r, ctx, piece, req_range);
     } else if (piece->type == zip_central_directory_piece) {

--- a/ngx_http_zip_module.h
+++ b/ngx_http_zip_module.h
@@ -28,6 +28,7 @@ typedef struct {
     unsigned    missing_crc32:1;
     unsigned    need_zip64:1;
     unsigned    need_zip64_offset:1;
+    unsigned    is_directory:1;
 } ngx_http_zip_file_t;
 
 typedef struct {
@@ -41,6 +42,7 @@ typedef struct {
 typedef enum {
     zip_header_piece, //local file header
     zip_file_piece, // file data
+    zip_dir_piece, // directory data
     zip_trailer_piece, // data descriptor (for files without CRC, exists if bit 3 of GP flag is set),
     zip_trailer_piece64, // the same but for zip64 (if zip64 extended information extra field is in file header)
     zip_central_directory_piece,

--- a/ngx_http_zip_parsers.c
+++ b/ngx_http_zip_parsers.c
@@ -22,6 +22,7 @@ ngx_http_zip_file_init(ngx_http_zip_file_t *parsing_file)
     parsing_file->missing_crc32 = 0;
     parsing_file->need_zip64 = 0;
     parsing_file->need_zip64_offset = 0;
+    parsing_file->is_directory = 0;
 }
 
 static size_t
@@ -74,29 +75,29 @@ ngx_http_zip_clean_range(ngx_http_zip_range_t *range,
 }
 
 
-#line 78 "ngx_http_zip_parsers.c"
+#line 79 "ngx_http_zip_parsers.c"
 static const char _request_actions[] = {
-	0, 1, 1, 1, 2, 1, 3, 1, 
-	4, 1, 5, 1, 6, 1, 7, 1, 
-	8, 2, 0, 6
+	0, 1, 2, 1, 3, 1, 4, 1, 
+	5, 1, 6, 1, 7, 1, 8, 1, 
+	9, 2, 0, 7, 2, 1, 2
 };
 
 static const char _request_key_offsets[] = {
-	0, 0, 7, 8, 11, 14, 16, 18, 
-	19, 26, 27, 28, 31
+	0, 0, 7, 8, 11, 14, 17, 19, 
+	20, 27, 28, 29, 32
 };
 
 static const char _request_trans_keys[] = {
 	45, 48, 57, 65, 70, 97, 102, 32, 
 	32, 48, 57, 32, 48, 57, 32, 63, 
-	32, 63, 32, 32, 48, 57, 65, 70, 
-	97, 102, 32, 32, 0, 10, 13, 10, 
-	13, 45, 48, 57, 65, 70, 97, 102, 
-	0
+	64, 32, 63, 32, 32, 48, 57, 65, 
+	70, 97, 102, 32, 32, 0, 10, 13, 
+	10, 13, 45, 48, 57, 65, 70, 97, 
+	102, 0
 };
 
 static const char _request_single_lengths[] = {
-	0, 1, 1, 1, 1, 2, 2, 1, 
+	0, 1, 1, 1, 1, 3, 2, 1, 
 	1, 1, 1, 3, 3
 };
 
@@ -106,29 +107,29 @@ static const char _request_range_lengths[] = {
 };
 
 static const char _request_index_offsets[] = {
-	0, 0, 5, 7, 10, 13, 16, 19, 
-	21, 26, 28, 30, 34
+	0, 0, 5, 7, 10, 13, 17, 20, 
+	22, 27, 29, 31, 35
 };
 
 static const char _request_indicies[] = {
 	0, 2, 2, 2, 1, 3, 1, 3, 
-	4, 1, 5, 4, 1, 5, 1, 6, 
-	8, 9, 7, 11, 10, 3, 12, 12, 
-	12, 1, 1, 13, 15, 14, 1, 17, 
-	17, 16, 18, 18, 0, 2, 2, 2, 
-	1, 0
+	4, 1, 5, 4, 1, 5, 1, 7, 
+	6, 9, 10, 8, 12, 11, 3, 13, 
+	13, 13, 1, 1, 14, 16, 15, 1, 
+	18, 18, 17, 19, 19, 0, 2, 2, 
+	2, 1, 0
 };
 
 static const char _request_trans_targs[] = {
 	2, 0, 8, 3, 4, 5, 6, 6, 
-	7, 9, 11, 7, 8, 10, 10, 7, 
-	11, 12, 12
+	6, 7, 9, 11, 7, 8, 10, 10, 
+	7, 11, 12, 12
 };
 
 static const char _request_trans_actions[] = {
-	17, 0, 17, 0, 9, 0, 1, 0, 
-	3, 3, 13, 0, 11, 5, 0, 7, 
-	0, 15, 0
+	17, 0, 17, 0, 9, 0, 1, 20, 
+	0, 3, 3, 13, 0, 11, 5, 0, 
+	7, 0, 15, 0
 };
 
 static const char _request_eof_actions[] = {
@@ -141,7 +142,7 @@ static const int request_start = 1;
 static const int request_en_main = 1;
 
 
-#line 77 "ngx_http_zip_parsers.rl"
+#line 78 "ngx_http_zip_parsers.rl"
 
 
 ngx_int_t
@@ -154,12 +155,12 @@ ngx_http_zip_parse_request(ngx_http_zip_ctx_t *ctx)
     ngx_http_zip_file_t *parsing_file = NULL;
 
     
-#line 158 "ngx_http_zip_parsers.c"
+#line 159 "ngx_http_zip_parsers.c"
 	{
 	cs = request_start;
 	}
 
-#line 163 "ngx_http_zip_parsers.c"
+#line 164 "ngx_http_zip_parsers.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -234,7 +235,7 @@ _match:
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 90 "ngx_http_zip_parsers.rl"
+#line 91 "ngx_http_zip_parsers.rl"
 	{
             parsing_file = ngx_array_push(&ctx->files);
             ngx_http_zip_file_init(parsing_file);
@@ -243,38 +244,52 @@ _match:
         }
 	break;
 	case 1:
-#line 97 "ngx_http_zip_parsers.rl"
+#line 98 "ngx_http_zip_parsers.rl"
+	{
+            parsing_file->is_directory = 1;
+            // Directory has no content.
+            parsing_file->size = 0;
+            parsing_file->crc32 = 0;
+            parsing_file->missing_crc32 = 0;
+            parsing_file->uri.data = NULL;
+            parsing_file->uri.len = 0;
+            parsing_file->args.data = NULL;
+            parsing_file->args.len = 0;
+        }
+	break;
+	case 2:
+#line 110 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->uri.data = p;
             parsing_file->uri.len = 1;
         }
 	break;
-	case 2:
-#line 102 "ngx_http_zip_parsers.rl"
+	case 3:
+#line 115 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->uri.len = destructive_url_decode_len(parsing_file->uri.data, p);
         }
 	break;
-	case 3:
-#line 105 "ngx_http_zip_parsers.rl"
+	case 4:
+#line 118 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->args.data = p;
         }
 	break;
-	case 4:
-#line 108 "ngx_http_zip_parsers.rl"
+	case 5:
+#line 121 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->args.len = p - parsing_file->args.data;
         }
 	break;
-	case 5:
-#line 111 "ngx_http_zip_parsers.rl"
+	case 6:
+#line 124 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->size = parsing_file->size * 10 + ((*p) - '0');
         }
 	break;
-	case 6:
-#line 114 "ngx_http_zip_parsers.rl"
+	case 7:
+#line 127 "ngx_http_zip_parsers.rl"
 	{
             if ((*p) == '-') {
                 ctx->missing_crc32 = 1;
@@ -286,19 +301,19 @@ _match:
             }
         }
 	break;
-	case 7:
-#line 124 "ngx_http_zip_parsers.rl"
+	case 8:
+#line 137 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->filename.data = p;
         }
 	break;
-	case 8:
-#line 127 "ngx_http_zip_parsers.rl"
+	case 9:
+#line 140 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->filename.len = p - parsing_file->filename.data;
         }
 	break;
-#line 302 "ngx_http_zip_parsers.c"
+#line 317 "ngx_http_zip_parsers.c"
 		}
 	}
 
@@ -314,13 +329,13 @@ _again:
 	unsigned int __nacts = (unsigned int) *__acts++;
 	while ( __nacts-- > 0 ) {
 		switch ( *__acts++ ) {
-	case 8:
-#line 127 "ngx_http_zip_parsers.rl"
+	case 9:
+#line 140 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->filename.len = p - parsing_file->filename.data;
         }
 	break;
-#line 324 "ngx_http_zip_parsers.c"
+#line 339 "ngx_http_zip_parsers.c"
 		}
 	}
 	}
@@ -328,7 +343,7 @@ _again:
 	_out: {}
 	}
 
-#line 145 "ngx_http_zip_parsers.rl"
+#line 162 "ngx_http_zip_parsers.rl"
 
 
     /* suppress warning */
@@ -344,7 +359,7 @@ _again:
 }
 
 
-#line 348 "ngx_http_zip_parsers.c"
+#line 363 "ngx_http_zip_parsers.c"
 static const char _range_actions[] = {
 	0, 1, 0, 1, 1, 1, 2, 2, 
 	0, 1, 2, 3, 1
@@ -395,7 +410,7 @@ static const int range_start = 1;
 static const int range_en_main = 1;
 
 
-#line 162 "ngx_http_zip_parsers.rl"
+#line 179 "ngx_http_zip_parsers.rl"
 
 
 ngx_int_t
@@ -408,12 +423,12 @@ ngx_http_zip_parse_range(ngx_http_request_t *r, ngx_str_t *range_str, ngx_http_z
     u_char *pe = range_str->data + range_str->len;
 
     
-#line 412 "ngx_http_zip_parsers.c"
+#line 427 "ngx_http_zip_parsers.c"
 	{
 	cs = range_start;
 	}
 
-#line 417 "ngx_http_zip_parsers.c"
+#line 432 "ngx_http_zip_parsers.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -487,7 +502,7 @@ _match:
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 174 "ngx_http_zip_parsers.rl"
+#line 191 "ngx_http_zip_parsers.rl"
 	{
             if (range) {
                 if (ngx_http_zip_clean_range(range, prefix, suffix, ctx) == NGX_ERROR) {
@@ -503,18 +518,18 @@ _match:
         }
 	break;
 	case 1:
-#line 188 "ngx_http_zip_parsers.rl"
+#line 205 "ngx_http_zip_parsers.rl"
 	{ range->start = range->start * 10 + ((*p) - '0'); }
 	break;
 	case 2:
-#line 190 "ngx_http_zip_parsers.rl"
+#line 207 "ngx_http_zip_parsers.rl"
 	{ range->end = range->end * 10 + ((*p) - '0'); prefix = 0; }
 	break;
 	case 3:
-#line 192 "ngx_http_zip_parsers.rl"
+#line 209 "ngx_http_zip_parsers.rl"
 	{ suffix = 1; }
 	break;
-#line 518 "ngx_http_zip_parsers.c"
+#line 533 "ngx_http_zip_parsers.c"
 		}
 	}
 
@@ -527,7 +542,7 @@ _again:
 	_out: {}
 	}
 
-#line 205 "ngx_http_zip_parsers.rl"
+#line 222 "ngx_http_zip_parsers.rl"
 
 
     /* suppress warning */

--- a/t/nginx/html/zip-empty-dirs.txt
+++ b/t/nginx/html/zip-empty-dirs.txt
@@ -1,0 +1,4 @@
+1a6349c5 24 /file1.txt file1.txt
+0        0  @directory empty_dir1/
+5d70c4d3 25 /file2.txt file2.txt
+0        0  @directory empty_dir2/

--- a/t/nginx/html/zip-only-empty-dirs.txt
+++ b/t/nginx/html/zip-only-empty-dirs.txt
@@ -1,0 +1,2 @@
+0        0  @directory empty_dir1/
+0        0  @directory empty_dir2/

--- a/t/ziptest.pl
+++ b/t/ziptest.pl
@@ -2,7 +2,7 @@
 
 # TODO tests for Zip64
 
-use Test::More tests => 93;
+use Test::More tests => 103;
 use LWP::UserAgent;
 use Archive::Zip;
 
@@ -150,6 +150,22 @@ is($response->code, 200, "Returns OK with spaces and plus in URLs");
 
 $zip = test_zip_archive($response->content, "with spaces and plus in the URLs");
 is($zip->numberOfMembers(), 2, "Correct number in spaces and plus ZIP");
+
+########## Package empty directories
+
+$response = $ua->get("$http_root/zip-empty-dirs.txt");
+$zip = test_zip_archive($response->content, "with empty directories");
+is($response->code, 200, "Returns OK with mixed empty directories and files");
+is($zip->memberNamed("file1.txt")->isBinaryFile(), 1, "file1.txt exists in archive");
+is($zip->memberNamed("empty_dir1/")->isDirectory(), 1, "empty_dir1 exists in archive");
+is($zip->memberNamed("file2.txt")->isBinaryFile(), 1, "file2.txt exists in archive");
+is($zip->memberNamed("empty_dir2/")->isDirectory(), 1, "empty_dir2 exists in archive");
+
+$response = $ua->get("$http_root/zip-only-empty-dirs.txt");
+$zip = write_temp_zip($response->content);
+is($response->code, 200, "Returns OK with only empty directories");
+is($zip->memberNamed("empty_dir1/")->isDirectory(), 1, "empty_dir1 exists in archive");
+is($zip->memberNamed("empty_dir2/")->isDirectory(), 1, "empty_dir2 exists in archive");
 
 
 open LARGEFILE, ">", "nginx/html/largefile.txt";


### PR DESCRIPTION
We had a need to be able to create archives that contain empty directories. It was not possible with existing tools, since directories are implicitly declared when the file paths contain their names. For this reason I've added a special marker `@directory` that is recognized in place of an `url`. So, as per example, you can now declare them:

    1034ab38 428    /foo.txt   My Document1.txt
    83e8110b 100339 /bar.txt   My Other Document1.txt
    0        0      @directory My empty directory