### PR TITLE
A fix for my recent changed regarding empty directories.

### DIFF
--- a/ngx_http_zip_parsers.c
+++ b/ngx_http_zip_parsers.c
@@ -78,26 +78,27 @@ ngx_http_zip_clean_range(ngx_http_zip_range_t *range,
 #line 79 "ngx_http_zip_parsers.c"
 static const char _request_actions[] = {
 	0, 1, 2, 1, 3, 1, 4, 1, 
-	5, 1, 6, 1, 7, 1, 8, 1, 
-	9, 2, 0, 7, 2, 1, 2
+	6, 1, 7, 1, 8, 1, 9, 2, 
+	0, 7, 2, 3, 1, 2, 5, 1
+	
 };
 
 static const char _request_key_offsets[] = {
-	0, 0, 7, 8, 11, 14, 17, 19, 
-	20, 27, 28, 29, 32
+	0, 0, 7, 8, 11, 14, 16, 18, 
+	19, 26, 27, 28, 31
 };
 
 static const char _request_trans_keys[] = {
 	45, 48, 57, 65, 70, 97, 102, 32, 
 	32, 48, 57, 32, 48, 57, 32, 63, 
-	64, 32, 63, 32, 32, 48, 57, 65, 
-	70, 97, 102, 32, 32, 0, 10, 13, 
-	10, 13, 45, 48, 57, 65, 70, 97, 
-	102, 0
+	32, 63, 32, 32, 48, 57, 65, 70, 
+	97, 102, 32, 32, 0, 10, 13, 10, 
+	13, 45, 48, 57, 65, 70, 97, 102, 
+	0
 };
 
 static const char _request_single_lengths[] = {
-	0, 1, 1, 1, 1, 3, 2, 1, 
+	0, 1, 1, 1, 1, 2, 2, 1, 
 	1, 1, 1, 3, 3
 };
 
@@ -107,34 +108,34 @@ static const char _request_range_lengths[] = {
 };
 
 static const char _request_index_offsets[] = {
-	0, 0, 5, 7, 10, 13, 17, 20, 
-	22, 27, 29, 31, 35
+	0, 0, 5, 7, 10, 13, 16, 19, 
+	21, 26, 28, 30, 34
 };
 
 static const char _request_indicies[] = {
 	0, 2, 2, 2, 1, 3, 1, 3, 
-	4, 1, 5, 4, 1, 5, 1, 7, 
-	6, 9, 10, 8, 12, 11, 3, 13, 
-	13, 13, 1, 1, 14, 16, 15, 1, 
-	18, 18, 17, 19, 19, 0, 2, 2, 
-	2, 1, 0
+	4, 1, 5, 4, 1, 5, 1, 6, 
+	8, 9, 7, 11, 10, 3, 12, 12, 
+	12, 1, 1, 13, 15, 14, 1, 17, 
+	17, 16, 18, 18, 0, 2, 2, 2, 
+	1, 0
 };
 
 static const char _request_trans_targs[] = {
 	2, 0, 8, 3, 4, 5, 6, 6, 
-	6, 7, 9, 11, 7, 8, 10, 10, 
-	7, 11, 12, 12
+	7, 9, 11, 7, 8, 10, 10, 7, 
+	11, 12, 12
 };
 
 static const char _request_trans_actions[] = {
-	17, 0, 17, 0, 9, 0, 1, 20, 
-	0, 3, 3, 13, 0, 11, 5, 0, 
-	7, 0, 15, 0
+	15, 0, 15, 0, 7, 0, 1, 0, 
+	18, 3, 11, 0, 9, 5, 0, 21, 
+	0, 13, 0
 };
 
 static const char _request_eof_actions[] = {
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 15, 0
+	0, 0, 0, 13, 0
 };
 
 static const int request_start = 1;
@@ -155,12 +156,12 @@ ngx_http_zip_parse_request(ngx_http_zip_ctx_t *ctx)
     ngx_http_zip_file_t *parsing_file = NULL;
 
     
-#line 159 "ngx_http_zip_parsers.c"
+#line 160 "ngx_http_zip_parsers.c"
 	{
 	cs = request_start;
 	}
 
-#line 164 "ngx_http_zip_parsers.c"
+#line 165 "ngx_http_zip_parsers.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -246,50 +247,54 @@ _match:
 	case 1:
 #line 98 "ngx_http_zip_parsers.rl"
 	{
-            parsing_file->is_directory = 1;
-            // Directory has no content.
-            parsing_file->size = 0;
-            parsing_file->crc32 = 0;
-            parsing_file->missing_crc32 = 0;
-            parsing_file->uri.data = NULL;
-            parsing_file->uri.len = 0;
-            parsing_file->args.data = NULL;
-            parsing_file->args.len = 0;
+            if (parsing_file->args.len == 0
+                    && parsing_file->uri.len == sizeof("@directory") - 1
+                    && ngx_strncmp(parsing_file->uri.data, "@directory", parsing_file->uri.len) == 0) {
+                parsing_file->is_directory = 1;
+                // Directory has no content.
+                parsing_file->size = 0;
+                parsing_file->crc32 = 0;
+                parsing_file->missing_crc32 = 0;
+                parsing_file->uri.data = NULL;
+                parsing_file->uri.len = 0;
+                parsing_file->args.data = NULL;
+                parsing_file->args.len = 0;
+            }
         }
 	break;
 	case 2:
-#line 110 "ngx_http_zip_parsers.rl"
+#line 114 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->uri.data = p;
             parsing_file->uri.len = 1;
         }
 	break;
 	case 3:
-#line 115 "ngx_http_zip_parsers.rl"
+#line 119 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->uri.len = destructive_url_decode_len(parsing_file->uri.data, p);
         }
 	break;
 	case 4:
-#line 118 "ngx_http_zip_parsers.rl"
+#line 122 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->args.data = p;
         }
 	break;
 	case 5:
-#line 121 "ngx_http_zip_parsers.rl"
+#line 125 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->args.len = p - parsing_file->args.data;
         }
 	break;
 	case 6:
-#line 124 "ngx_http_zip_parsers.rl"
+#line 128 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->size = parsing_file->size * 10 + ((*p) - '0');
         }
 	break;
 	case 7:
-#line 127 "ngx_http_zip_parsers.rl"
+#line 131 "ngx_http_zip_parsers.rl"
 	{
             if ((*p) == '-') {
                 ctx->missing_crc32 = 1;
@@ -302,18 +307,18 @@ _match:
         }
 	break;
 	case 8:
-#line 137 "ngx_http_zip_parsers.rl"
+#line 141 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->filename.data = p;
         }
 	break;
 	case 9:
-#line 140 "ngx_http_zip_parsers.rl"
+#line 144 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->filename.len = p - parsing_file->filename.data;
         }
 	break;
-#line 317 "ngx_http_zip_parsers.c"
+#line 322 "ngx_http_zip_parsers.c"
 		}
 	}
 
@@ -330,12 +335,12 @@ _again:
 	while ( __nacts-- > 0 ) {
 		switch ( *__acts++ ) {
 	case 9:
-#line 140 "ngx_http_zip_parsers.rl"
+#line 144 "ngx_http_zip_parsers.rl"
 	{
             parsing_file->filename.len = p - parsing_file->filename.data;
         }
 	break;
-#line 339 "ngx_http_zip_parsers.c"
+#line 344 "ngx_http_zip_parsers.c"
 		}
 	}
 	}
@@ -343,7 +348,7 @@ _again:
 	_out: {}
 	}
 
-#line 162 "ngx_http_zip_parsers.rl"
+#line 164 "ngx_http_zip_parsers.rl"
 
 
     /* suppress warning */
@@ -359,7 +364,7 @@ _again:
 }
 
 
-#line 363 "ngx_http_zip_parsers.c"
+#line 368 "ngx_http_zip_parsers.c"
 static const char _range_actions[] = {
 	0, 1, 0, 1, 1, 1, 2, 2, 
 	0, 1, 2, 3, 1
@@ -410,7 +415,7 @@ static const int range_start = 1;
 static const int range_en_main = 1;
 
 
-#line 179 "ngx_http_zip_parsers.rl"
+#line 181 "ngx_http_zip_parsers.rl"
 
 
 ngx_int_t
@@ -423,12 +428,12 @@ ngx_http_zip_parse_range(ngx_http_request_t *r, ngx_str_t *range_str, ngx_http_z
     u_char *pe = range_str->data + range_str->len;
 
     
-#line 427 "ngx_http_zip_parsers.c"
+#line 432 "ngx_http_zip_parsers.c"
 	{
 	cs = range_start;
 	}
 
-#line 432 "ngx_http_zip_parsers.c"
+#line 437 "ngx_http_zip_parsers.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -502,7 +507,7 @@ _match:
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 191 "ngx_http_zip_parsers.rl"
+#line 193 "ngx_http_zip_parsers.rl"
 	{
             if (range) {
                 if (ngx_http_zip_clean_range(range, prefix, suffix, ctx) == NGX_ERROR) {
@@ -518,18 +523,18 @@ _match:
         }
 	break;
 	case 1:
-#line 205 "ngx_http_zip_parsers.rl"
+#line 207 "ngx_http_zip_parsers.rl"
 	{ range->start = range->start * 10 + ((*p) - '0'); }
 	break;
 	case 2:
-#line 207 "ngx_http_zip_parsers.rl"
+#line 209 "ngx_http_zip_parsers.rl"
 	{ range->end = range->end * 10 + ((*p) - '0'); prefix = 0; }
 	break;
 	case 3:
-#line 209 "ngx_http_zip_parsers.rl"
+#line 211 "ngx_http_zip_parsers.rl"
 	{ suffix = 1; }
 	break;
-#line 533 "ngx_http_zip_parsers.c"
+#line 538 "ngx_http_zip_parsers.c"
 		}
 	}
 
@@ -542,7 +547,7 @@ _again:
 	_out: {}
 	}
 
-#line 222 "ngx_http_zip_parsers.rl"
+#line 224 "ngx_http_zip_parsers.rl"
 
 
     /* suppress warning */

--- a/ngx_http_zip_parsers.rl
+++ b/ngx_http_zip_parsers.rl
@@ -95,16 +95,20 @@ ngx_http_zip_parse_request(ngx_http_zip_ctx_t *ctx)
             parsing_file->index = ctx->files.nelts - 1;
         }
 
-        action is_directory {
-            parsing_file->is_directory = 1;
-            // Directory has no content.
-            parsing_file->size = 0;
-            parsing_file->crc32 = 0;
-            parsing_file->missing_crc32 = 0;
-            parsing_file->uri.data = NULL;
-            parsing_file->uri.len = 0;
-            parsing_file->args.data = NULL;
-            parsing_file->args.len = 0;
+        action check_directory {
+            if (parsing_file->args.len == 0
+                    && parsing_file->uri.len == sizeof("@directory") - 1
+                    && ngx_strncmp(parsing_file->uri.data, "@directory", parsing_file->uri.len) == 0) {
+                parsing_file->is_directory = 1;
+                // Directory has no content.
+                parsing_file->size = 0;
+                parsing_file->crc32 = 0;
+                parsing_file->missing_crc32 = 0;
+                parsing_file->uri.data = NULL;
+                parsing_file->uri.len = 0;
+                parsing_file->args.data = NULL;
+                parsing_file->args.len = 0;
+            }
         }
 
         action start_uri {
@@ -146,11 +150,9 @@ ngx_http_zip_parse_request(ngx_http_zip_ctx_t *ctx)
                   [0-9]+ $size_incr
                   " "+
                   (
-                    "@directory" >is_directory
-                    |
                     [^? ]+ >start_uri %end_uri
                     ( "?" [^ ]+ >start_args %end_args )?
-                  )
+                  ) %check_directory
                   " "+
                   [^ ] >start_filename
                   [^\r\n\0]* %end_filename;

--- a/t/nginx.conf
+++ b/t/nginx.conf
@@ -93,6 +93,18 @@ http {
             proxy_pass                  http://ziplist;
         }
 
+        location = @not_directory {
+            rewrite .* /file1.txt break;
+
+            root       html;
+        }
+
+        location = @directory_not {
+            rewrite .* /file2.txt break;
+
+            root       html;
+        }
+
         #error_page  404              /404.html;
 
         # redirect server error pages to the static page /50x.html

--- a/t/nginx/html/zip-not-empty-dirs.txt
+++ b/t/nginx/html/zip-not-empty-dirs.txt
@@ -1,0 +1,2 @@
+1a6349c5 24 @not_directory file1.txt
+5d70c4d3 25 @directory_not file2.txt

--- a/t/ziptest.pl
+++ b/t/ziptest.pl
@@ -2,7 +2,7 @@
 
 # TODO tests for Zip64
 
-use Test::More tests => 115;
+use Test::More tests => 120;
 use LWP::UserAgent;
 use Archive::Zip;
 
@@ -166,6 +166,12 @@ is($response->code, 200, "Returns OK with only empty directories");
 $zip = write_temp_zip($response->content);
 is($zip->memberNamed("empty_dir1/")->isDirectory(), 1, "empty_dir1 exists in archive");
 is($zip->memberNamed("empty_dir2/")->isDirectory(), 1, "empty_dir2 exists in archive");
+
+$response = $ua->get("$http_root/zip-not-empty-dirs.txt");
+is($response->code, 200, "Returns OK with urls that start with @ but not a '\@directory' marker");
+$zip = test_zip_archive($response->content, "with not empty directories");
+is($zip->memberNamed("file1.txt")->isBinaryFile(), 1, "file1.txt exists in archive");
+is($zip->memberNamed("file2.txt")->isBinaryFile(), 1, "file2.txt exists in archive");
 
 ########## Pass headers in sub-requests
 


### PR DESCRIPTION
Due to my lackluster knowledge of Ragel State Machine I have made an incorrect detection of `@directory` token that was miss-firing on any URL that starts with `@` (ie `@something_else`). I have fixed the issue now and covered it with tests. I'm honestly sorry for this mess.