### PR TITLE
Make mod_zip compatible with nginx 1.23.0+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [ gcc, clang ]
-        version: [ 1.19.10, 1.20.2, 1.21.4 ]
+        version: [ 1.19.10, 1.20.2, 1.21.4, 1.22.0, 1.23.0 ]
     steps:
       - name: Install carton
         run: sudo apt install carton

--- a/config
+++ b/config
@@ -36,3 +36,15 @@ if [ $ngx_found = yes ]; then
     CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
     ngx_found=no
 fi
+
+ngx_feature="multi-value headers are linked lists (nginx 1.23.0+)"
+ngx_feature_name="NGX_ZIP_MULTI_HEADERS_LINKED_LISTS"
+ngx_feature_run=yes
+ngx_feature_incs="#include \"nginx.h\""
+ngx_feature_path="src/core"
+ngx_feature_test="
+#if nginx_version < 1023000
+#error multi headers are no linked lists
+#endif
+"
+. auto/feature

--- a/ngx_http_zip_file.c
+++ b/ngx_http_zip_file.c
@@ -3,6 +3,7 @@
 #include "ngx_http_zip_file.h"
 #include "ngx_http_zip_file_format.h"
 #include "ngx_http_zip_endian.h"
+#include "ngx_http_zip_headers.h"
 
 #ifdef NGX_ZIP_HAVE_ICONV
 #include <iconv.h>
@@ -252,7 +253,7 @@ ngx_http_zip_generate_pieces(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx)
     // because UFT-8 flag (zip_utf8_flag) is set default for templates.
     ngx_int_t variable_header_status = NGX_OK;
     if (r->upstream) {
-        variable_header_status = ngx_http_variable_unknown_header(vv, &ngx_http_zip_header_name_separator,
+        variable_header_status = ngx_http_zip_variable_unknown_header(r, vv, &ngx_http_zip_header_name_separator,
                 &r->upstream->headers_in.headers.part, sizeof("upstream_http_")-1);
     } else {
         vv->not_found = 1;
@@ -266,7 +267,7 @@ ngx_http_zip_generate_pieces(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx)
 #ifdef NGX_ZIP_HAVE_ICONV
         variable_header_status = NGX_OK;
         if (r->upstream) {
-            variable_header_status = ngx_http_variable_unknown_header(vv, &ngx_http_zip_header_charset_name,
+            variable_header_status = ngx_http_zip_variable_unknown_header(r, vv, &ngx_http_zip_header_charset_name,
                     &r->upstream->headers_in.headers.part, sizeof("upstream_http_")-1);
         } else {
             vv->not_found = 1;
@@ -431,7 +432,7 @@ ngx_http_zip_generate_pieces(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx)
 
     // Collect names of original request's header fields that
     // have to be present in each of the issued sub-requests.
-    variable_header_status = ngx_http_variable_unknown_header(vv, &ngx_http_zip_header_name_pass_headers,
+    variable_header_status = ngx_http_zip_variable_unknown_header(r, vv, &ngx_http_zip_header_name_pass_headers,
             &r->upstream->headers_in.headers.part, sizeof("upstream_http_")-1);
 
     if (variable_header_status == NGX_OK && !vv->not_found) {

--- a/ngx_http_zip_headers.h
+++ b/ngx_http_zip_headers.h
@@ -13,3 +13,7 @@ ngx_int_t ngx_http_zip_init_multipart_range(ngx_http_request_t *r,
 ngx_int_t ngx_http_zip_init_subrequest_headers(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx,
         ngx_http_request_t *sr, ngx_http_zip_range_t *piece_range,
         ngx_http_zip_range_t *req_range);
+
+ngx_int_t ngx_http_zip_variable_unknown_header(ngx_http_request_t *r,
+                                           ngx_http_variable_value_t *v, ngx_str_t *var, ngx_list_part_t *part,
+                                           size_t prefix);

--- a/ngx_http_zip_module.c
+++ b/ngx_http_zip_module.c
@@ -201,13 +201,13 @@ ngx_http_zip_main_request_header_filter(ngx_http_request_t *r)
     /* Look for X-Archive-Files */
     ngx_int_t variable_header_status = NGX_OK;
     if (r->upstream) {
-        variable_header_status = ngx_http_variable_unknown_header(vv,
+        variable_header_status = ngx_http_zip_variable_unknown_header(r, vv,
                 &ngx_http_zip_header_variable_name,
-                &r->upstream->headers_in.headers.part, sizeof("upstream_http_") - 1); 
+                &r->upstream->headers_in.headers.part, sizeof("upstream_http_") - 1);
     } else if (r->headers_out.status == NGX_HTTP_OK) {
-        variable_header_status = ngx_http_variable_unknown_header(vv,
+        variable_header_status = ngx_http_zip_variable_unknown_header(r, vv,
                 &ngx_http_zip_header_variable_name,
-                &r->headers_out.headers.part, sizeof("upstream_http_") - 1); 
+                &r->headers_out.headers.part, sizeof("upstream_http_") - 1);
     } else {
         vv->not_found = 1;
     }


### PR DESCRIPTION
This PR makes mod_zip (also) compatible with nginx 1.23.0+. 

The two necessary changes were:
- `r->headers_out.cache_control` is now a linked list
- `ngx_http_variable_unknown_header` now needs the request as first parameter

Fixes #92
