### PR TITLE
Fix memory usage when reading input

### DIFF
--- a/ngx_http_zip_module.h
+++ b/ngx_http_zip_module.h
@@ -57,7 +57,7 @@ typedef struct {
 } ngx_http_zip_piece_t;
 
 typedef struct {
-    ngx_str_t              *unparsed_request;
+    ngx_array_t             unparsed_request;
     ngx_http_zip_piece_t   *pieces;
     ngx_array_t             files;
     ngx_array_t             ranges;

--- a/ngx_http_zip_parsers.c
+++ b/ngx_http_zip_parsers.c
@@ -150,9 +150,9 @@ ngx_int_t
 ngx_http_zip_parse_request(ngx_http_zip_ctx_t *ctx)
 {
     int cs;
-    u_char *p = ctx->unparsed_request->data;
-    u_char *pe = ctx->unparsed_request->data + ctx->unparsed_request->len;
-    u_char *eof = ctx->unparsed_request->data + ctx->unparsed_request->len;
+    u_char *p = ctx->unparsed_request.elts;
+    u_char *pe = p + ctx->unparsed_request.nelts;
+    u_char *eof = pe;
     ngx_http_zip_file_t *parsing_file = NULL;
 
     

--- a/ngx_http_zip_parsers.rl
+++ b/ngx_http_zip_parsers.rl
@@ -81,9 +81,9 @@ ngx_int_t
 ngx_http_zip_parse_request(ngx_http_zip_ctx_t *ctx)
 {
     int cs;
-    u_char *p = ctx->unparsed_request->data;
-    u_char *pe = ctx->unparsed_request->data + ctx->unparsed_request->len;
-    u_char *eof = ctx->unparsed_request->data + ctx->unparsed_request->len;
+    u_char *p = ctx->unparsed_request.elts;
+    u_char *pe = p + ctx->unparsed_request.nelts;
+    u_char *eof = pe;
     ngx_http_zip_file_t *parsing_file = NULL;
 
     %%{


### PR DESCRIPTION
Currently, every time mod_zip reads 8KB, it allocates a new string, copies all existing data,
and doesn't free the old string. This results in GBs of memory use for a 10MB input.

Just use an nginx array which automatically doubles in size as needed.
(Still leaks memory, but not as much.)

Fixes https://github.com/evanmiller/mod_zip/issues/67
