### PR TITLE
Don't decode and re-encode URLs unnecessarily.

### DIFF
--- a/ngx_http_zip_module.c
+++ b/ngx_http_zip_module.c
@@ -549,6 +549,7 @@ ngx_http_zip_send_file_piece(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx,
         return NGX_ERROR;
     }
 
+    sr->internal = 0;
     sr->allow_ranges = 1;
     sr->subrequest_ranges = 1;
     sr->single_range = 1;

--- a/ngx_http_zip_parsers.c
+++ b/ngx_http_zip_parsers.c
@@ -25,26 +25,6 @@ ngx_http_zip_file_init(ngx_http_zip_file_t *parsing_file)
     parsing_file->is_directory = 0;
 }
 
-static size_t
-destructive_url_decode_len(unsigned char* start, unsigned char* end)
-{
-    unsigned char *read_pos = start, *write_pos = start;
-
-    for (; read_pos < end; read_pos++) {
-        unsigned char ch = *read_pos;
-        if (ch == '+') {
-            ch = ' ';
-        }
-        if (ch == '%' && (read_pos + 2 < end)) {
-            ch = ngx_hextoi(read_pos + 1, 2);
-            read_pos += 2;
-        }
-        *(write_pos++) = ch;
-    }
-
-    return write_pos - start;
-}
-
 
 static ngx_int_t
 ngx_http_zip_clean_range(ngx_http_zip_range_t *range,
@@ -272,7 +252,7 @@ _match:
 	case 3:
 #line 119 "ngx_http_zip_parsers.rl"
 	{
-            parsing_file->uri.len = destructive_url_decode_len(parsing_file->uri.data, p);
+            parsing_file->uri.len = p - parsing_file->uri.data;
         }
 	break;
 	case 4:

--- a/ngx_http_zip_parsers.rl
+++ b/ngx_http_zip_parsers.rl
@@ -23,27 +23,6 @@ ngx_http_zip_file_init(ngx_http_zip_file_t *parsing_file)
     parsing_file->is_directory = 0;
 }
 
-static size_t
-destructive_url_decode_len(unsigned char* start, unsigned char* end)
-{
-    unsigned char *read_pos = start, *write_pos = start;
-
-    for (; read_pos < end; read_pos++) {
-        unsigned char ch = *read_pos;
-        if (ch == '+') {
-            ch = ' ';
-        }
-        if (ch == '%' && (read_pos + 2 < end)) {
-            ch = ngx_hextoi(read_pos + 1, 2);
-            read_pos += 2;
-        }
-        *(write_pos++) = ch;
-    }
-
-    return write_pos - start;
-}
-
-
 static ngx_int_t
 ngx_http_zip_clean_range(ngx_http_zip_range_t *range,
         int prefix, int suffix, ngx_http_zip_ctx_t *ctx)
@@ -117,7 +96,7 @@ ngx_http_zip_parse_request(ngx_http_zip_ctx_t *ctx)
         }
 
         action end_uri {
-            parsing_file->uri.len = destructive_url_decode_len(parsing_file->uri.data, fpc);
+            parsing_file->uri.len = p - parsing_file->uri.data;
         }
         action start_args {
             parsing_file->args.data = fpc;


### PR DESCRIPTION
This causes two problems:
- '+' gets incorrectly decoded to ' '
- '%2B' gets decoded to '+', but not encoded back to '%2B', resulting in a slightly different URL

Fixes https://github.com/evanmiller/mod_zip/issues/95