### PR TITLE
Fix SSL stalled connection while sendind large headers

### DIFF
--- a/ngx_http_zip_file.c
+++ b/ngx_http_zip_file.c
@@ -499,10 +499,7 @@ ngx_http_zip_file_header_chain_link(ngx_http_request_t *r, ngx_http_zip_ctx_t *c
 
     b->memory = 1;
     b->last = b->pos + len;
-#if (NGX_HTTP_SSL)
-    b->flush = !!r->connection->ssl;
-#endif
-
+    
     /* A note about the ZIP format: in order to appease all ZIP software I
      * could find, the local file header contains the file sizes but not the
      * CRC-32, even though setting the third bit of the general purpose bit

--- a/ngx_http_zip_module.c
+++ b/ngx_http_zip_module.c
@@ -609,7 +609,7 @@ ngx_http_zip_send_piece(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx,
         rc = ngx_http_zip_send_trailer_piece(r, ctx, piece, req_range);
     } else if (piece->type == zip_central_directory_piece) {
         rc = ngx_http_zip_send_central_directory_piece(r, ctx, piece, req_range);
-    } 
+    }
 
     return rc;
 }

--- a/ngx_http_zip_module.c
+++ b/ngx_http_zip_module.c
@@ -448,7 +448,11 @@ ngx_http_zip_main_request_body_filter(ngx_http_request_t *r,
         if (rc == NGX_HTTP_RANGE_NOT_SATISFIABLE) {
             return ngx_http_special_response_handler(r, rc);
         }
-        if ((rc = ngx_http_send_header(r)) != NGX_OK) {
+        rc = ngx_http_send_header(r);
+
+        if (rc != NGX_OK && !(rc == NGX_AGAIN && r->connection->buffered)) {
+            return rc;
+        }
             return rc;
         }
     }

--- a/ngx_http_zip_module.c
+++ b/ngx_http_zip_module.c
@@ -609,7 +609,7 @@ ngx_http_zip_send_piece(ngx_http_request_t *r, ngx_http_zip_ctx_t *ctx,
         rc = ngx_http_zip_send_trailer_piece(r, ctx, piece, req_range);
     } else if (piece->type == zip_central_directory_piece) {
         rc = ngx_http_zip_send_central_directory_piece(r, ctx, piece, req_range);
-    }
+    } 
 
     return rc;
 }
@@ -683,6 +683,9 @@ ngx_http_zip_send_pieces(ngx_http_request_t *r,
                 pieces_sent++;
                 ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "mod_zip: no ranges / sending piece type %d", piece->type);
                 rc = ngx_http_zip_send_piece(r, ctx, piece, NULL);
+                if (rc == NGX_AGAIN && r->connection->buffered && !r->postponed) {
+                    rc = NGX_OK;
+                }
             }
             break;
         case 1:


### PR DESCRIPTION
In addition to #103 we need to treat NGX_AGAIN as right answer on buffered connection with SSL.