### PR TITLE
Fix stalled SSL connection when sending large headers

### DIFF
--- a/ngx_http_zip_module.c
+++ b/ngx_http_zip_module.c
@@ -448,7 +448,9 @@ ngx_http_zip_main_request_body_filter(ngx_http_request_t *r,
         if (rc == NGX_HTTP_RANGE_NOT_SATISFIABLE) {
             return ngx_http_special_response_handler(r, rc);
         }
-        if ((rc = ngx_http_send_header(r)) != NGX_OK) {
+        rc = ngx_http_send_header(r);
+        if (rc != NGX_OK &&
+            !(rc == NGX_AGAIN && r->connection->buffered)) {
             return rc;
         }
     }


### PR DESCRIPTION
In addition to #103. If we send large enough headers, more than postpone_output (1460) but less than ssl_buffer(16k) it also will be buffered and ngx_http_send_header returns NGX_AGAIN. So we need to threat it as OK and send more data.
Not sure will it return r->connection->buffered as well in any case with NGX_AGAIN.