### PR TITLE
Fix for crc calculation on upstream subrequest

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,7 +62,6 @@ the following HTTP header:
 
     X-Archive-Pass-Headers: <header-name>[:<header-name>]*
 
-
 Re-encoding filenames
 ---
 


### PR DESCRIPTION
CRC32 values are now correctly stored for upstream requests.